### PR TITLE
Show agent summaries in CLI progress

### DIFF
--- a/workflow.py
+++ b/workflow.py
@@ -114,7 +114,8 @@ class CouncilWorkflow:
         round_feedback = [
             {
                 "agent_id": response.agent_id,
-                "feedback": response.content
+                "feedback": response.content,
+                "summary": response.metadata.get("summary", "")
             }
             for response in feedback_responses
         ]


### PR DESCRIPTION
## Summary
- parse out a `Summary:` section from agent responses
- ask each agent to end their replies with a single-sentence summary
- surface these summaries via the workflow callback and CLI progress handler
- keep only the main text for further processing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810b5df9c0833282f8e69b618d39e0